### PR TITLE
Bug:  if the user didn't create the sessions folder manually,  the ap…

### DIFF
--- a/lib/handler/FileSessionHandler.js
+++ b/lib/handler/FileSessionHandler.js
@@ -27,7 +27,7 @@ function FileSessionHandler(path) {
  * @return {String} Same session data as passed in write() or empty string when non-existent or on failure
  */
 FileSessionHandler.prototype.read = function (sessionId, callback) {
-    fs.readFile(path.join(this.__path, sessionId), 'utf-8', function (err, file) {
+    fs.readFile(path.normalize(path.join(this.__path, sessionId)), 'utf-8', function (err, file) {
         if (err) {
             file = '';
         }
@@ -47,7 +47,10 @@ FileSessionHandler.prototype.read = function (sessionId, callback) {
  * @return {Boolean} true on success, false on failure
  */
 FileSessionHandler.prototype.write = function (sessionId, data, callback) {
-    fs.writeFile(path.join(this.__path, sessionId), data, 'utf-8', function (err) {
+	if(!fs.existsSync(this.__path)){
+        fs.mkdirSync(this.__path);
+    }
+    fs.writeFile(path.normalize(path.join(this.__path, sessionId)), data, 'utf-8', function (err) {
         if (callback) {
             callback(err);
         }


### PR DESCRIPTION
…p will throw I/O error.  Another issue is that the Path.join function will join two path with "/" in Windows platform, so the Path.nomalize function is the best choice.
